### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/dtormoen/tsk/compare/v0.1.0...v0.2.0) - 2025-07-07
+
+### Added
+
+- plan template includes success criteria and out of scope section
+- ensure proxy image is built before task execution
+
+### Fixed
+
+- release storage mutex lock after task completion to prevent server deadlock
+- remove rust specific language from default templates
+
+### Other
+
+- add comprehensive Docker builds documentation
+- migrate task_manager tests from mocks to real implementations
+- replace git mock implementations with integration tests
+- replace git mock implementations with integration tests
+- add repo_path parameter to is_git_repository method
+- eliminate unsafe blocks in XdgDirectories tests
+- add project specific task templates that mention rust best practices
+- update install instructions in README.md
+
 ## [0.1.0](https://github.com/dtormoen/tsk/releases/tag/v0.1.0) - 2025-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `tsk-ai` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  XdgDirectories::new_with_paths, previously in file /tmp/.tmpnbOpuj/tsk-ai/src/storage/xdg.rs:37
  XdgDirectories::new_with_paths, previously in file /tmp/.tmpnbOpuj/tsk-ai/src/storage/xdg.rs:37

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  tsk::storage::xdg::XdgDirectories::new now takes 1 parameters instead of 0, in /tmp/.tmpSTBN2j/tsk/src/storage/xdg.rs:49
  tsk::storage::XdgDirectories::new now takes 1 parameters instead of 0, in /tmp/.tmpSTBN2j/tsk/src/storage/xdg.rs:49

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  GitOperations::is_git_repository now takes 2 instead of 1 parameters, in file /tmp/.tmpSTBN2j/tsk/src/context/git_operations.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/dtormoen/tsk/compare/v0.1.0...v0.2.0) - 2025-07-07

### Added

- plan template includes success criteria and out of scope section
- ensure proxy image is built before task execution

### Fixed

- release storage mutex lock after task completion to prevent server deadlock
- remove rust specific language from default templates

### Other

- add comprehensive Docker builds documentation
- migrate task_manager tests from mocks to real implementations
- replace git mock implementations with integration tests
- replace git mock implementations with integration tests
- add repo_path parameter to is_git_repository method
- eliminate unsafe blocks in XdgDirectories tests
- add project specific task templates that mention rust best practices
- update install instructions in README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).