### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/dtormoen/tsk/compare/v0.3.1...v0.3.2) - 2025-08-05
+
+### Added
+
+- expand project Dockerfile search to include user-level config
+- add bulk operations for retry and delete commands
+- upgrade Docker images to Ubuntu 24.04 and resolve GID conflict
+
+### Fixed
+
+- ensure project layer detection uses copied repository in server mode
+
 ## [0.3.1](https://github.com/dtormoen/tsk/compare/v0.3.0...v0.3.1) - 2025-07-18
 
 This release fixes an issue where Dockerfiles in projects could conflict with tsk's own 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/dtormoen/tsk/compare/v0.3.1...v0.3.2) - 2025-08-05

### Added

- expand project Dockerfile search to include user-level config
- add bulk operations for retry and delete commands
- upgrade Docker images to Ubuntu 24.04 and resolve GID conflict

### Fixed

- ensure project layer detection uses copied repository in server mode
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).