### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/dtormoen/tsk/compare/v0.4.0...v0.4.1) - 2025-09-01
+
+### Fixed
+
+- handle non-JSON output gracefully in Claude Code log processor
+- rework Python tech-stack to use UV with proper virtual environment
+- add support for symlinks in git repository copy operations
+
 ## [0.4.0](https://github.com/dtormoen/tsk/compare/v0.3.2...v0.4.0) - 2025-08-25
 
 This release is largely focused on refactoring which will help create a solid foundation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/dtormoen/tsk/compare/v0.4.0...v0.4.1) - 2025-09-01

### Fixed

- handle non-JSON output gracefully in Claude Code log processor
- rework Python tech-stack to use UV with proper virtual environment
- add support for symlinks in git repository copy operations
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).