### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/dtormoen/tsk/compare/v0.5.1...v0.5.2) - 2025-10-01
+
+### Fixed
+
+- handle empty git repositories gracefully
+
 ## [0.5.1](https://github.com/dtormoen/tsk/compare/v0.5.0...v0.5.1) - 2025-09-25
 
 This release mainly adds a few new features:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,7 +2384,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.2](https://github.com/dtormoen/tsk/compare/v0.5.1...v0.5.2) - 2025-10-01

### Fixed

- handle empty git repositories gracefully
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).