### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/dtormoen/tsk/compare/v0.5.2...v0.5.3) - 2025-10-21
+
+### Fixed
+
+- don't mount .claude.json to avoid corrupting it
+- deduplicate consecutive parsing errors in Claude Code log processor
+- detect lua before python
+
 ## [0.5.2](https://github.com/dtormoen/tsk/compare/v0.5.1...v0.5.2) - 2025-10-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,7 +2384,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.5.2 -> 0.5.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.3](https://github.com/dtormoen/tsk/compare/v0.5.2...v0.5.3) - 2025-10-21

### Fixed

- don't mount .claude.json to avoid corrupting it
- deduplicate consecutive parsing errors in Claude Code log processor
- detect lua before python
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).