### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/dtormoen/tsk/compare/v0.6.0...v0.6.1) - 2025-11-25
+
+### Added
+
+- add uv to base image
+- add quit-when-done mode to server start
+
+### Fixed
+
+- add line buffering to Docker log streaming to prevent parse errors
+- resolve git fetch errors when copying repos from specific commits
+
+### Other
+
+- update deps
+- *(docker)* simplify agent installation and environment setup
+
 ## [0.6.0](https://github.com/dtormoen/tsk/compare/v0.5.4...v0.6.0) - 2025-10-26
 
 This release has a few large changes. First we've added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "AI-powered development task delegation and sandboxing tool"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/dtormoen/tsk/compare/v0.6.0...v0.6.1) - 2025-11-25

### Added

- add uv to base image
- add quit-when-done mode to server start

### Fixed

- add line buffering to Docker log streaming to prevent parse errors
- resolve git fetch errors when copying repos from specific commits

### Other

- update deps
- *(docker)* simplify agent installation and environment setup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).