### PR TITLE
chore: release v0.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9](https://github.com/dtormoen/tsk-tsk/compare/v0.10.8...v0.10.9) - 2026-04-03
+
+### Added
+
+- surface warmup failures to `tsk wait` and `tsk add --wait`
+
 ## [0.10.8](https://github.com/dtormoen/tsk-tsk/compare/v0.10.7...v0.10.8) - 2026-04-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsk-ai"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsk-ai"
-version = "0.10.8"
+version = "0.10.9"
 edition = "2024"
 authors = ["Danny Tormoen <dtormoen@gmail.com>"]
 description = "tsk-tsk: keeping your agents out of trouble with sandboxed coding agent automation"


### PR DESCRIPTION



## 🤖 New release

* `tsk-ai`: 0.10.8 -> 0.10.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.9](https://github.com/dtormoen/tsk-tsk/compare/v0.10.8...v0.10.9) - 2026-04-03

### Added

- surface warmup failures to `tsk wait` and `tsk add --wait`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).